### PR TITLE
Don't create `package/` directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ npm install -g generator-p
 ## Usage
 
 ```bash
-yo p
+$ mkdir package-name && cd $_
+$ yo p
 ```
 
 You will then be prompted for some information that will be used to generate an npm package.

--- a/app/index.js
+++ b/app/index.js
@@ -44,20 +44,18 @@ var PGenerator = yeoman.generators.Base.extend({
       this.description = props.description;
       this.year = (new Date()).getFullYear();
 
-      this.dest.mkdir(this.packageName)
+      this.template('_README.md', 'README.md');
+      this.template('_LICENSE.md', 'LICENSE.md');
+      this.template('_package.json', 'package.json');
+      this.template('_index.js', 'index.js');
 
-      this.template('_README.md', this.packageName + '/README.md');
-      this.template('_LICENSE.md', this.packageName + '/LICENSE.md');
-      this.template('_package.json', this.packageName + '/package.json');
-      this.template('_index.js', this.packageName + '/index.js');
+      this.dest.mkdir('test');
+      this.template('_test.js', 'test/test.js');
 
-      this.dest.mkdir(this.packageName + '/test');
-      this.template('_test.js', this.packageName + '/test/test.js');
-
-      this.src.copy('editorconfig', this.packageName + '/.editorconfig');
-      this.src.copy('travis.yml', this.packageName + '/.travis.yml');
-      this.src.copy('gitignore', this.packageName + '/.gitignore');
-      this.src.copy('jshintrc', this.packageName + '/.jshintrc');
+      this.src.copy('editorconfig', '.editorconfig');
+      this.src.copy('travis.yml', '.travis.yml');
+      this.src.copy('gitignore', '.gitignore');
+      this.src.copy('jshintrc', '.jshintrc');
 
       done();
     }.bind(this));

--- a/test/test.js
+++ b/test/test.js
@@ -20,13 +20,13 @@ describe('p:app', function () {
   it('creates the correct files', function () {
 
     assert.file([
-      'p-package/package.json',
-      'p-package/.editorconfig',
-      'p-package/.travis.yml',
-      'p-package/index.js',
-      'p-package/README.md',
-      'p-package/LICENSE.md',
-      'p-package/test/test.js'
+      'package.json',
+      '.editorconfig',
+      '.travis.yml',
+      'index.js',
+      'README.md',
+      'LICENSE.md',
+      'test/test.js'
     ]);
   });
 });


### PR DESCRIPTION
Currently the generator was creating a `package-name/` directory, and dumping all its files in there. That's something not one other yeoman generator does (at least no official ones). A 'normal' generator would copy all its files to the directory the user ran `yo p` in. I think we should adapt that behaviour too.
